### PR TITLE
Use a variable instead of hardcoded user root

### DIFF
--- a/mysqldump-minio/README.md
+++ b/mysqldump-minio/README.md
@@ -7,6 +7,7 @@
 This image is based on the newest stable Debian and contains MySQL/MariaDB mysqldump and AWS CLI 2 utilities which allow backup of MySQL/MariaDB databases directly to S3 compatible storage like Minio. Backups are going to be compressed using bzip2. The entrypoint of the image is a bash script which does the actual backup. At the moment this script probably doesn't work with AWS S3 (will be implemented just upon request, please open an issue for this). Configuration can be done using the following environment variables:
 
 - MARIADB_HOST
+- MARIADB_USER
 - MARIADB_PASSWORD
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
@@ -36,11 +37,13 @@ spec:
               env:
                 - name: MARIADB_HOST
                   value: mariadb
+                - name: MARIADB_USER
+                  value: backupuser
                 - name: MARIADB_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: mariadb
-                      key: mariadb-root-password
+                      key: mariadb-backupuser-password
                 - name: AWS_ACCESS_KEY_ID
                   value: { { requiredEnv "HOME_MINIO_ACCESS_KEY" } }
                 - name: AWS_SECRET_ACCESS_KEY

--- a/mysqldump-minio/backup.sh
+++ b/mysqldump-minio/backup.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-DBS=$(mysql -h ${MARIADB_HOST} -u root -p${MARIADB_PASSWORD} -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema|performance_schema|mysql|test)")
+DBS=$(mysql -h ${MARIADB_HOST} -u {MARIADB_USER} -p${MARIADB_PASSWORD} -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema|performance_schema|mysql|test)")
 
 for DB in $DBS; do
     echo "dumping ${DB}"
     DATE=$(date +"%Y%m%d")
     S3_FILE="${DB}_${DATE}.sql.bz2"
-    mysqldump -h ${MARIADB_HOST} -u root -p${MARIADB_PASSWORD} --routines --triggers ${DB} | bzip2 -c | aws --endpoint-url=${S3_ENDPOINT} --no-progress s3 cp - s3://${S3_BUCKET}/${S3_FILE}
+    mysqldump -h ${MARIADB_HOST} -u {MARIADB_USER} -p${MARIADB_PASSWORD} --routines --triggers ${DB} | bzip2 -c | aws --endpoint-url=${S3_ENDPOINT} --no-progress s3 cp - s3://${S3_BUCKET}/${S3_FILE}
 done


### PR DESCRIPTION
To give some flexibility to users who don't use "root" user for backup